### PR TITLE
fix bug in DAC useSignalLEDs

### DIFF
--- a/src/TriggerScope_V4/TriggerScope_V4.ino
+++ b/src/TriggerScope_V4/TriggerScope_V4.ino
@@ -1206,17 +1206,14 @@ void setDac(byte dNum,int dVal)
 {  
   dac_write(10,0, dNum, dVal); // Send dac_code
   //led indication
-  for (byte d=0; d < 16; d++) 
-  {
-    if (dacState[dNum] > 0) 
-    {
-      mcp.digitalWrite(dacLed, 1);
-      return;
-    }
-  }
   if (useSignalLEDs_)
   {
-    mcp.digitalWrite(dacLed, 0);
+    int dacSum = 0;
+    for (byte d=0; d < 16; d++)
+    {
+      dacSum += dacState[d];
+    }
+    mcp.digitalWrite(dacLed, dacSum > 0);
   }
 }
 


### PR DESCRIPTION
This PR fixes a bug in the implementation of the `useSignalLEDs_` check for DAC lines. The bug fix eliminates delays associated with setting the signal LEDs when changing DAC states.